### PR TITLE
Refactor hasher and schema evolution code

### DIFF
--- a/authkit/hashkit/hasher.go
+++ b/authkit/hashkit/hasher.go
@@ -33,18 +33,18 @@ type Option func(hasher *BCryptHasher)
 // If provided cost exceed out of acceptable boundary
 // then min or max cost wil be set.
 func WithCost(cost int) Option {
-	var finalCost int
+	c := cost
 
-	if cost < bcrypt.MinCost {
-		finalCost = bcrypt.MinCost
+	if c < bcrypt.MinCost {
+		c = bcrypt.MinCost
 	}
 
-	if cost > bcrypt.MaxCost {
-		finalCost = bcrypt.MaxCost
+	if c > bcrypt.MaxCost {
+		c = bcrypt.MaxCost
 	}
 
 	return func(h *BCryptHasher) {
-		h.cost = finalCost
+		h.cost = c
 	}
 }
 

--- a/dbkit/litekit/schema_evolution.go
+++ b/dbkit/litekit/schema_evolution.go
@@ -217,7 +217,7 @@ func (e *Evolver) loadMutations() ([]Mutation, error) {
 			}
 
 			evolutions = append(evolutions, Mutation{
-				version: uint(i + 1),
+				version: uint(i + 1), //nolint:gosec // i is always positive
 				changes: changes,
 			})
 		}


### PR DESCRIPTION
- Simplify WithCost function in BCryptHasher by using a local variable
- Add nolint comment for safe version calculation in schema evolution