### PR TITLE
chore: switch dependabot schedule to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "daily"


### PR DESCRIPTION
## Summary
- Change gomod dependabot update interval from \`weekly\` to \`daily\` so dependency bumps arrive sooner.

## Test plan
- [x] Config validated by dependabot upon next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)