### PR TITLE
fix(httpkit): make access-log flag suppress global LoggingMiddleware for built-in endpoints

### DIFF
--- a/httpkit/http_listener.go
+++ b/httpkit/http_listener.go
@@ -591,6 +591,8 @@ func (l *ListenerHTTP) configureHealth(cfg ListenerConfig) error {
 	l.router.Route(cfg.health.route, func(health chi.Router) {
 		if cfg.health.accessLogsEnabled {
 			health.Use(LoggingMiddleware(l.logger))
+		} else {
+			health.Use(NoAccessLogMiddleware())
 		}
 
 		if cfg.health.metricsForEndpointEnabled {
@@ -623,29 +625,33 @@ func (l *ListenerHTTP) configureHealth(cfg ListenerConfig) error {
 }
 
 func (l *ListenerHTTP) configureMetrics(cfg ListenerConfig) error {
-	if cfg.metrics.enable {
-		if cfg.metrics.route == "" {
-			return errors.New("empty metrics route")
-		}
-
-		if !strings.HasPrefix(cfg.metrics.route, "/") {
-			return fmt.Errorf("invalid metrics route: %q (route should start with '/' slash)",
-				cfg.metrics.route,
-			)
-		}
-
-		l.router.Route(cfg.metrics.route, func(metrics chi.Router) {
-			if cfg.metrics.accessLogsEnabled {
-				metrics.Use(LoggingMiddleware(l.logger))
-			}
-
-			if cfg.metrics.metricsForEndpointEnabled {
-				metrics.Use(MetricsMiddleware())
-			}
-
-			metrics.Get("/", l.metricsHandler)
-		})
+	if !cfg.metrics.enable {
+		return nil
 	}
+
+	if cfg.metrics.route == "" {
+		return errors.New("empty metrics route")
+	}
+
+	if !strings.HasPrefix(cfg.metrics.route, "/") {
+		return fmt.Errorf("invalid metrics route: %q (route should start with '/' slash)",
+			cfg.metrics.route,
+		)
+	}
+
+	l.router.Route(cfg.metrics.route, func(metrics chi.Router) {
+		if cfg.metrics.accessLogsEnabled {
+			metrics.Use(LoggingMiddleware(l.logger))
+		} else {
+			metrics.Use(NoAccessLogMiddleware())
+		}
+
+		if cfg.metrics.metricsForEndpointEnabled {
+			metrics.Use(MetricsMiddleware())
+		}
+
+		metrics.Get("/", l.metricsHandler)
+	})
 
 	return nil
 }
@@ -666,6 +672,8 @@ func (l *ListenerHTTP) configureProfiler(cfg ListenerConfig) error {
 		l.router.Route(cfg.profiler.route, func(profiler chi.Router) {
 			if cfg.profiler.accessLogsEnabled {
 				profiler.Use(LoggingMiddleware(l.logger))
+			} else {
+				profiler.Use(NoAccessLogMiddleware())
 			}
 
 			profiler.Mount("/", middleware.Profiler())

--- a/httpkit/middlewares.go
+++ b/httpkit/middlewares.go
@@ -1,6 +1,7 @@
 package httpkit
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -23,6 +24,24 @@ func RedirectSlashesMiddleware() Middleware    { return middleware.RedirectSlash
 func ProfilerMiddleware() http.Handler         { return middleware.Profiler() }
 func CORSMiddleware(o cors.Options) Middleware { return cors.Handler(o) }
 
+// noAccessLogKey is the context key used to signal that access logging should be suppressed.
+type noAccessLogKey struct{}
+
+// NoAccessLogMiddleware suppresses access logging for the current request when
+// LoggingMiddleware is present in the chain. It works by setting a flag that
+// LoggingMiddleware checks after the handler returns.
+func NoAccessLogMiddleware() Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ptr, ok := r.Context().Value(noAccessLogKey{}).(*bool); ok {
+				*ptr = true
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // LoggingMiddleware represents logging middleware.
 func LoggingMiddleware(logger *slog.Logger) Middleware {
 	return func(next http.Handler) http.Handler {
@@ -31,11 +50,18 @@ func LoggingMiddleware(logger *slog.Logger) Middleware {
 
 			var reqErr error
 
+			skip := false
+
 			ctx := ctxkit.SetLogErrHook(r.Context(), func(err error) { reqErr = err })
+			ctx = context.WithValue(ctx, noAccessLogKey{}, &skip)
 
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
 			next.ServeHTTP(ww, r.WithContext(ctx))
+
+			if skip {
+				return
+			}
 
 			status := ww.Status()
 


### PR DESCRIPTION
## Summary

- `HealthCheckAccessLog(false)` (and the equivalent for metrics/profiler) previously only controlled whether a *local* `LoggingMiddleware` was added to the subroute. A global `LoggingMiddleware` registered via `WithGlobalMiddlewares` was unaffected — the flag was effectively inert in the common setup.
- Adds a cooperative suppression mechanism: `LoggingMiddleware` now plants a `*bool` skip flag in the request context; `NoAccessLogMiddleware()` (new exported middleware) flips it. Since the subroute runs inside the global middleware's `next.ServeHTTP` call, the flag is visible when the global logger checks after the handler returns.
- Built-in subroutes (`/health`, `/metrics`, `/pprof`) now inject `NoAccessLogMiddleware` when `accessLogsEnabled == false`, making the per-endpoint flag authoritative regardless of where the logger is attached.
- `configureMetrics` refactored to early-return style to match `configureHealth` and stay within the `nestif` lint threshold.

## Test plan

- [ ] `golangci-lint run` — 0 issues
- [ ] `go test -race -cover ./...` — all pass
- [ ] Manual: register `LoggingMiddleware` globally, set `HealthCheckAccessLog(false)`, confirm `/health` produces no access-log line
- [ ] Manual: set `HealthCheckAccessLog(true)`, confirm `/health` still logs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)